### PR TITLE
Mention available network protocols and options for PNPS

### DIFF
--- a/src/docs/admin/ProActiveAdminGuide.adoc
+++ b/src/docs/admin/ProActiveAdminGuide.adoc
@@ -400,19 +400,56 @@ The main troubles you may have to face are the following ones:
 * You get an *authentication error*: this is probably due to your default credentials file which cannot be found. In the "Connection" tab of the Configuration Editor (Figure 5.4, “Configuration Editor window - Connection Tab (Resource Manager Registration)”), you can choose the credentials file you want. You can select, for instance, the credentials file located at PROACTIVE_HOME/config/authentication/scheduler.cred or your own credentials file.
 * The node seems to be well started but you cannot see it in the Resource Manager interface : in this case, make sure that the *port number* is the good one. Do not forget that the runtime port number is incremented from the initial ProActive Resource Manager port number. You can see exactly on which port your runtime has been started looking at the log file described above.
 
+== Available Network Protocols
+
+ProActive Workflows and Scheduling offers several protocols for
+the Scheduler and nodes to communicate. These protocols provide different
+features: _speed_, _security_, _fast error detection_, _firewall_ or
+_NAT friendliness_ but one of the protocols can offer all these features at
+the same time.
+Consequently, the selection should be made carefully. Below are introduced
+available network protocols.
+Configuration and properties are discussed in <<_network_properties>>.
+
+=== ProActive Network Protocol
+
+ProActive Network Protocol (PNP) is the general purpose communication protocol
+(`pnp://` scheme). Its performances are quite similar to the well known Java RMI
+protocol, but it is much more robust and network friendly. It requires only one
+TCP port per JVM and no shared registry. Besides, it enables fast network
+failure discovery and better scalability.
+PNP binds to a given TCP port at startup. All incoming communications use this
+TCP port. Deploying the Scheduler or a node with PNP requires to open one and
+only one incoming TCP port per machine.
+
+=== ProActive Network Protocol over SSL
+
+ProActive Network Protocol over SSL (PNPS) is the PNP protocol wrapped inside
+an SSL tunnel. The URI scheme used for the protocol is `pnps://`. It includes
+the same features as PNP plus ciphering and optionally authentication.
+Using SSL creates some CPU overhead which implies that PNPS is slower than PNP.
+
+=== ProActive Message Routing
+
+ProActive Message Routing (PAMR) allows the deployment of the Scheduler and nodes
+behind a firewall. Its associated URI
+scheme is `pamr://`. PAMR has the weakest expectations on how the network is
+configured. Unlike all the other communication protocols introduced previously,
+it has been designed to work when only outgoing TCP connections are available.
+
 == Installation on a Cluster with Firewall
 
-When the configuration of the network is unfriendly (ports closed, firewalls,...) the ProActive Scheduler allows
-you to connect nodes without significant changes in your network firewall configuration.
-It relies on the *PAMR* protocol (ProActive Message Routing Protocol) that has the weakest expectations on
-how the network is configured.
+When incoming connections are not allowed (ports closed, firewalls, etc.), the
+ProActive Scheduler allows you to connect nodes without significant changes
+in your network firewall configuration. It relies on the PAMR protocol.
 
-Unlike all the other communication protocols, PAMR does *not* expect *bidirectional* TCP connections.
-It has been designed to work when only outgoing TCP connections are available. Such environments can be encountered due to:
+This last does *not* expect *bidirectional* TCP connections.
+It has been designed to work when only outgoing TCP connections are available.
+Such environments can be encountered due to:
 
-* Network address translation devices
-* Firewalls allowing only outgoing connection (this is the default setup of many personal firewalls)
-* Virtual Machines with a virtualized network stack
+  - Network address translation devices
+  - Firewalls allowing only outgoing connections (this is the default setup of many firewalls)
+  - Virtual Machines with a virtualized network stack
 
 image::firewall.png[]
 
@@ -981,6 +1018,7 @@ include::./references/SchedulerPropertiesReference.adoc[]
 
 include::./references/RMPropertiesReference.adoc[]
 
+[[_network_properties]]
 === Network Properties
 
 include::./references/NetworkPropertiesReference.adoc[]

--- a/src/docs/admin/references/NetworkPropertiesReference.adoc
+++ b/src/docs/admin/references/NetworkPropertiesReference.adoc
@@ -1,107 +1,149 @@
+Configuration files related to network properties for the Scheduler and nodes
+are located respectively in:
 
-- +proactive.communication.protocol+: Represents the communication protocol, i.e. the protocol used to export
- objects on remote JVMs. At this stage, several protocols are supported: RMI(rmi), HTTP(http), IBIS/RMI(ibis),
-  SSH tunneling for RMI/HTTP(rmissh), ProActive Message Routing(pamr). It means that once the JVM starts,
-  nodes and active objects that will be created on this JVM will export themselves using the protocol
-  specified in proactive.communication.protocol property. They will be reachable transparently through
-  the given protocol.
+  - `PROACTIVE_HOME/config/network/server.ini`
+  - `PROACTIVE_HOME/config/network/node.ini`
+
+If you are using ProActive agents, then the configuration file location differs
+depending of the Operating System:
+
+  - On Unix OS, the default location is
+    `/opt/proactive-node/config/network/node.ini`
+  - On Windows OS, the default one is
+    `C:\Program Files (x86)\ProActiveAgent\schedworker\config\network\node.ini`.
+
+==== Common Network Properties
+
+The protocol to use by the Server and the nodes can be configured by setting a
+value to the property `proactive.communication.protocol`. It represents the
+protocol used to export objects on remote JVMs. At this stage, several protocols
+are supported: PNP (pnp), PNP over SSL (pnps), ProActive Message Routing (pamr).
 
 The Scheduler is only able to bind to one and only one address. Usually, this limitation is not
 seen by the user and no special configuration is required. The Scheduler tries to use the most suitable network
 address available. But sometimes, the Scheduler fails to elect the right IP address or the user wants to use
  a given IP address. In such case, you can specify the IP address to use by using theses properties:
- +proactive.hostname+, +proactive.net.interface+, +proactive.net.netmask+, +proactive.net.nolocal+, +proactive.net.noprivate+.
+ `proactive.hostname`, `proactive.net.interface`, `proactive.net.netmask`, `proactive.net.nolocal`, `proactive.net.noprivate`.
 
-IPv6 can be enabled by setting the +proactive.net.disableIPv6+ property to false . By default,
+IPv6 can be enabled by setting the `proactive.net.disableIPv6` property to false . By default,
 the Scheduler does not use IPv6 addresses.
 
-If none of the +proactive.hostname+ , +proactive.net.interface+ , +proactive.net.netmask+ ,
-+proactive.net.nolocal+ , +proactive.net.noprivate+ properties is defined, then the following algorithm is used to elect an IP address:
+If none of the `proactive.hostname`, `proactive.net.interface`, `proactive.net.netmask`,
+`proactive.net.nolocal` , `proactive.net.noprivate` properties is defined, then the following algorithm is used to elect an IP address:
 
-- If a public IP address is available, then use it. If several ones are available, one is randomly chosen.
-- If a private IP address is available, then use it. If several ones are available, one is randomly chosen.
-- If a loopback IP address is available, then use it. If several ones are available, one is randomly chosen.
-- If no IP address is available at all, then the runtime exits with an error message.
-- If +proactive.hostname+ is set, then the value returned by InetAddress.getByName(+proactive.hostname+)
+  - If a public IP address is available, then use it. If several ones are available, one is randomly chosen.
+  - If a private IP address is available, then use it. If several ones are available, one is randomly chosen.
+  - If a loopback IP address is available, then use it. If several ones are available, one is randomly chosen.
+  - If no IP address is available at all, then the runtime exits with an error message.
+  - If `proactive.hostname` is set, then the value returned by InetAddress.getByName(`proactive.hostname`)
  is elected. If no IP address is found, then the runtime exits with an error message.
 
-If +proactive.hostname+ is not set, and at least one of the +proactive.net.interface+ , +proactive.net.netmask+ , +proactive.net.nolocal+ , +proactive.net.noprivate+ is set, then one of the addresses matching all the requirements is elected. Requirements are:
+If `proactive.hostname` is not set, and at least one of the `proactive.net.interface` , `proactive.net.netmask` , `proactive.net.nolocal` , `proactive.net.noprivate` is set, then one of the addresses matching all the requirements is elected. Requirements are:
 
-- If +proactive.net.interface+ is set, then the IP address must be bound to the given network interface.
-- If +proactive.net.netmask+ is set, then the IP address must match the given netmask.
-- If +proactive.net.nolocal+ is set, then the IP address must not be a loopback address.
-- If +proactive.net.noprivate+ is set, then the IP address must not be a private address.
+- If `proactive.net.interface` is set, then the IP address must be bound to the given network interface.
+- If `proactive.net.netmask` is set, then the IP address must match the given netmask.
+- If `proactive.net.nolocal` is set, then the IP address must not be a loopback address.
+- If `proactive.net.noprivate` is set, then the IP address must not be a private address.
 
-- +proactive.useIPaddress+: If set to true, IP addresses will be used instead of machines names.
+- `proactive.useIPaddress`: If set to true, IP addresses will be used instead of machines names.
  This property is particularly useful to deal with sites that do not host a DNS.
 
-- ++proactive.hostname++: When this property is set, the host name on which the JVM is started
+- `proactive.hostname`: When this property is set, the host name on which the JVM is started
 is given by the value of the property. This property is particularly useful to deal with
 machines with two network interfaces.
 
 
 ==== PNP Protocol Properties
 
-The property +proactive.communication.protocol+ must be set to *pnp*.
+PNP allows the following options:
 
-- +proactive.pnp.port+: The TCP port to bind to. If not set PNP uses a random free port. If the specified
-TCP port is already used PNP will not start and an error message is displayed.
+  - `proactive.pnp.port`: The TCP port to bind to. If not set PNP uses a random free port. If the specified
+    TCP port is already used, PNP will not start and an error message is displayed.
 
-- +proactive.pnp.default_heartbeat+: PNP uses heartbeat messages to monitor TCP socket and
-discover network failures. This value determines how long PNP will wait before the connection
-is considered broken. Heartbeat messages are usually sent every default_heartbeat/2 ms. This value is
- in milliseconds. This value is a trade-off between fast error discovery and network overhead. The default
- value is 9000 ms. Setting this value to 0 disable the heartbeat mechanism and client will not be advertised of
-  network failure before the TCP timeout (which can be really long).
+  - `proactive.pnp.default_heartbeat`: PNP uses heartbeat messages to monitor the TCP socket and
+    discover network failures. This value determines how long PNP will wait before the connection
+    is considered broken. Heartbeat messages are usually sent every +default_heartbeat/2+ ms.
+    This value is a trade-off between fast error discovery and network overhead. The default
+    value is 9000 ms. Setting this value to 0 disables the heartbeat mechanism and client will not be
+    advertised of network failure before the TCP timeout (which can be really long).
 
-- +proactive.pnp.idle_timeout+: PNP channels are closed when unused to free system resources. Establishing a
- TCP connection is costly (at least 3 RTT) so PNP connections are not closed immediately but after a grace
-  time. By default the grace time is 60 000 ms. Setting this value to 0 disable the autoclosing mechanism,
-  connections are kept open forever.
+  - `proactive.pnp.idle_timeout`: PNP channels are closed when unused to free system resources. Establishing a
+    TCP connection is costly (at least 3 RTT) so PNP connections are not closed immediately but after a grace
+    time. By default the grace time is 60 000 ms. Setting this value to 0 disables the autoclosing mechanism,
+    connections are kept open forever.
+
+==== PNP over SSL Properties
+
+PNPS support the same options as PNP (in its own option name space) plus some SSL specific options:
+
+  - `proactive.pnps.port`: same as `proactive.pnp.port`
+  - `proactive.pnps.default_heartbeat`: same as `proactive.pnp.default_heartbeat`
+  - `proactive.pnps.idle_timeout`: same as `proactive.pnp.idle_timeout`
+  - `proactive.pnps.authenticate`: By default, PNPS only ciphers the communication but does not authenticate
+    nor the client nor the server. Setting this option to `true` enable client and server authentication.
+    If set to `true` the option `proactive.pnps.keystore` must also be set.
+  - `proactive.pnps.keystore`: Specify the keystore (containing the SSL private key) to use. The keystore must
+    be of type PKCS12. If not set a private key is dynamically generated for this execution.
+    Below is an example for creating a keystore by using the _keytool_ binary that is shipped with Java:
+
+    $JAVA_HOME/bin/keytool -genkey -keyalg RSA -keystore keystore.jks \
+           -validity 365 -keyalg RSA -keysize 2048 -storetype pkcs12
+
+  - `proactive.pnps.keystore.password`: the password associated to the keystore used by PNPS.
+
+When using the authentication and ciphering mode (or to speed up the initialization in ciphering only mode),
+the option `proactive.pnps.keystore` must be set and a keystore embedding the private SSL key must be
+generated. This keystore must be accessible to ProActive services but kept secret to others. The same applies
+to the configuration file that contains the keystore password defined with property
+`proactive.pnps.keystore.password`.
 
 ==== PAMR Protocol Properties
 
-- +proactive.pamr.router.address+: The address of the router to use. Must be set if message routing is enabled.
+PAMR options are listed below:
+
+- `proactive.pamr.router.address`: The address of the router to use. Must be set if message routing is enabled.
  It can be FQDN or an IP address.
 
-- +proactive.pamr.router.port+: The port of the router to use. Must be set if message routing is enabled.
+- `proactive.pamr.router.port`: The port of the router to use. Must be set if message routing is enabled.
 
-- +proactive.pamr.socketfactory+: The Socket Factory to use by the message routing protocol
+- `proactive.pamr.socketfactory`: The Socket Factory to use by the message routing protocol
 
-- +proactive.pamr.connect_timeout+: Sockets used by the PAMR remote object factory connect to the remote server
+- `proactive.pamr.connect_timeout`: Sockets used by the PAMR remote object factory connect to the remote server
 with a specified timeout value. A timeout of zero is interpreted as an infinite timeout.
 The connection will then block until established or an error occurs.
 
-- +proactive.pamr.agent.id+: This property can be set to obtain a given (and fixed) agent ID. This id must be declared
+- `proactive.pamr.agent.id`: This property can be set to obtain a given (and fixed) agent ID. This id must be declared
 in the router configuration and must be between 0 and 4096.
 
-- +proactive.pamr.agent.magic_cookie+: The Magic cookie to submit to the router.
-If +proactive.pamr.agent.id+ is set, then this property must also be set to be able
+- `proactive.pamr.agent.magic_cookie`: The Magic cookie to submit to the router.
+If `proactive.pamr.agent.id` is set, then this property must also be set to be able
 to use a reserved agent ID.
 
-===== PAMR over SSH Protocol Properties
+===== PAMR over SSH protocol properties
 
 To enable PAMR over SSH, ProActive nodes hosts should be able to SSH to router's host without password, using
 SSH keys.
 
-- +proactive.pamr.socketfactory+: The underlying Socket factory, should be +ssh+ to enable PAMR over SSH
+- `proactive.pamr.socketfactory`: The underlying Socket factory, should be `ssh` to enable PAMR over SSH
 
-- +proactive.pamrssh.port+: SSH port to use when connecting to router's host
+- `proactive.pamrssh.port`: SSH port to use when connecting to router's host
 
-- +proactive.pamrssh.username+: username to use when connecting to router's host
+- `proactive.pamrssh.username`: username to use when connecting to router's host
 
-- +proactive.pamrssh.key_directory+: directory when SSH keys can be found to access router's host. For instance
+- `proactive.pamrssh.key_directory`: directory when SSH keys can be found to access router's host. For instance
 /home/login/.ssh
 
-==== Enabling several communication protocols
+==== Enabling Several Communication Protocols
 
-- +proactive.communication.additional_protocols+: The set of protocol to use separated by commas.
+The next options are available to control multiprocol:
 
-- +proactive.communication.benchmark.parameter+:  This property is used pass parameters to the benchmark.
+- `proactive.communication.additional_protocols`: The set of protocol to use separated by commas.
+
+- `proactive.communication.benchmark.parameter`:  This property is used pass parameters to the benchmark.
 This could be a duration time, a size, ...
 This property is expressed as a String.
 
-- +proactive.communication.protocols.order+: A fixed order could be specified if protocol's
+- `proactive.communication.protocols.order`: A fixed order could be specified if protocol's
 performance is known in advance and won't change.
 This property explain a preferred order for a subset of protocols declared in the property
 proactive.communication.additional_protocols. If one of the specified protocol isn't exposed,
@@ -114,7 +156,6 @@ they are used in the order choose by the benchmark mechanism.
     Order : pnp
     This will give the order of use : pnp > rmi > http
 
-- +proactive.communication.protocols.order+: A fixed order could be specified if protocol's performance
+- `proactive.communication.protocols.order`: A fixed order could be specified if protocol's performance
 is known in advance and won't change.
 This automatically disabled	RemoteObject's Benchmark.
-


### PR DESCRIPTION
The pull-request describes the protocols that are available for the Scheduler and nodes to communicate. The administration guide only has been updated. A new section named  _Available Network Protocols_ has been added and the existing one called _Network Properties_ has been updated. The idea was to keep untouched as most as possible the existing structure. 

The readable version of the documentation associated to this pull-request is available below:
http://jenkins.activeeon.com/view/Pull%20Requests/job/documentation-pull-requests/35/jdk=JDK8,label=Linux-non-scheduling-jobs/artifact/build/asciidoc/html5/admin/ProActiveAdminGuide.html#_available_network_protocols

The current master is available at:
http://jenkins.activeeon.com/job/documentation/114/artifact/build/asciidoc/html5/admin/ProActiveAdminGuide.html


