### PR TITLE
Login file encryption documentation

### DIFF
--- a/src/docs/admin/ProActiveAdminGuide.adoc
+++ b/src/docs/admin/ProActiveAdminGuide.adoc
@@ -570,27 +570,80 @@ pa.scheduler.core.authentication.loginMethod=SchedulerLDAPLoginMethod
 By default, the ProActive Resource Manager stores users accounts, passwords, and group memberships (user or admin), in two files:
 
 * users and passwords accounts are stored in `PROACTIVE_HOME/config/authentication/login.cfg`.
-Each line has to follow the format *user:passwd*. The default `login.cfg` file is given hereafter:
+Each line has to follow the format *user:encypted password*.
+The default accounts in `login.cfg` file correspond to the following passwords, which are encrypted in the actual login.cfg file:
 +
-[source]
+.unencrypted_login.cfg
 ----
 admin:admin
 user:pwd
 demo:demo
+guest:pwd
+test:pwd
+radmin:pwd
+nsadmin:pwd
+provider:pwd
+scheduler:scheduler_pwd
+rm:rm_pwd
+watcher:watcher_pwd
+test_executor:pwd
 ----
 
 * users membership is stored in `PROACTIVE_HOME/config/authentication/group.cfg`. For each user registered in login.cfg,
 a group membership has to be defined in this file. Each line has to look like *user:group*. Group has to be
-user to have user rights, or admin to have administrator rights. Below is an extract of `group.cfg`:
+user to have user rights, or admin to have administrator rights. Below is an example `group.cfg` file:
 +
-[source]
+.group.cfg
 ----
 admin:admin
 demo:admin
+guest:guests
+rm:admin
+scheduler:user
 user:user
+watcher:watchers
 ----
 
 ProActive contains a set of predefined groups such as "user" and "admin". Groups are defined in `PROACTIVE_HOME/config/security.java.policy-server` as described in chapter <<User Permissions>>.
+
+In order to create new users, delete an existing user, or modify the groups or password for an existing user, a command-line tool is available.
+
+This command is available inside the *tools* folder: `PROACTIVE_HOME/tools/proactive-users`.
+You can check the command syntax using the -h option.
+
+----
+$ proactive-users -h
+usage: proactive-users [-C | -D | -U]  [-g <GROUPS>] [-gf <GROUPFILE>] [-h] [-kf <KEYFILE>] [-l <LOGIN>] [-lf <LOGINFILE>] [-p <PASSWORD>]
+----
+
+Here are examples of use:
+
+* Creating users
++
+----
+$ proactive-users -C -l user1 -p pwd1 -g user
+Created user user1 in H:\Install\scheduling\tools\..\config/authentication/login.cfg
+Added group user to user user1
+----
+The user with login "user1", password "pwd1" and group "user" was created
+
+* Updating users
++
+----
+$ proactive-users -U -l user1 -p pwd2 -g nsadmins,admin
+Changed password for user user1 in H:\Install\scheduling\tools\..\config/authentication/login.cfg
+Added group nsadmins to user user1
+Added group admin to user user1
+----
+User "user1" now has password pwd2 and groups nsadmins & admin (group "user" was removed).
+
+* Deleting users
++
+----
+$ proactive-users -D -l user1
+Deleted user user1 in H:\Install\scheduling\tools\..\config/authentication/login.cfg
+----
+User "user1" does not exist any more.
 
 === LDAP
 

--- a/src/docs/admin/ProActiveAdminGuide.adoc
+++ b/src/docs/admin/ProActiveAdminGuide.adoc
@@ -783,7 +783,10 @@ After this command, the user, called "your_user" here in this example, will be a
 +
 Following the procedure described in chapter <<File>>, groups must be associated to existing PAM users in the ProActive group file `PROACTIVE_HOME/config/authentication/group.cfg`.
 +
-In case of PAM users, the login file should not be modified as password authentication will be performed at the Linux system level.
+In case of PAM users, the login file should not be modified as password authentication will be performed at the Linux system level. Accordingly, you should not use the *proactive-users* command to associate groups to PAM users.
+
+NOTE: Similarly to the LDAP authentication, there is a fallback mechanism for login authentication, with the difference that it is always activated.
+A user defined in the ProActive login file always has precedence over the same user defined on the Linux system.
 
 == User Permissions
 

--- a/src/docs/admin/ProActiveAdminGuide.adoc
+++ b/src/docs/admin/ProActiveAdminGuide.adoc
@@ -737,14 +737,13 @@ Finally, in `config/authentication/ldap.cfg`, set keyStore and trustStore create
 
 . *Use fall back to file authentication*
 +
-You can use simultaneously file-based authentication and LDAP-based authentication. Then ProActive Scheduler can check user password and group membership in
-login and group files, as performed in FileLogin method, if user or group is not found in LDAP.
+You can use simultaneously file-based authentication and LDAP-based authentication. Then, ProActive Scheduler can check at first user password and group membership in
+login and group files, as performed in FileLogin method. If user or group is not found in login file, login or group will be searched in LDAP.
 It uses `pa.rm.defaultloginfilename` and `pa.rm.defaultgroupfilename` files to authenticate user and check group membership. There are two rules:
 
-* If LDAP group membership checking fails, fall back to group membership checking with group file.
+* If file group membership checking fails, fall back to group membership checking with LDAP.
 To activate this behavior set `pa.ldap.group.membership.fallback` to true, in LDAP configuration file.
-* If a user is not found in LDAP, fall back to authentication and group membership checking with login
-and group files. To activate this behavior, set `pa.ldap.authentication.fallback` to true, in LDAP configuration file.
+* If a user is not found in the login file, fall back to authentication and group membership checking with LDAP. To activate this behavior, set `pa.ldap.authentication.fallback` to true, in LDAP configuration file.
 
 === PAM
 


### PR DESCRIPTION
 - changed file authentication paragraph to the new format and display default passwords.
 - added documentation for the proactive-users script

 - fixed ldap fallback mechanism wrong precedence explanation.