### PR TITLE
Use older version of AsciiDoctor (1.5.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,10 @@ asciidoctor {
     }
 }
 
+asciidoctorj {
+    version = '1.5.1'
+}
+
 project.ext.branch = new File("$projectDir/src/docs/version-conf.js").text.split("'")[1]
 if (project.ext.branch.endsWith("-SNAPSHOT")) {
     project.ext.branch = 'master'


### PR DESCRIPTION
Use older version of AsciiDoctor (1.5.1)

Problem:
- Since we change the asciidoctor version to 1.5.3, the :docinfo: in the Admin and User-guide stopped working.

Solution:
- Set the gradle plugin up to use recently working AsciiDoctor version 1.5.1