### PR TITLE
Add documentation for PHP

### DIFF
--- a/src/docs/admin/references/NodeSourceInfrastructureReference.adoc
+++ b/src/docs/admin/references/NodeSourceInfrastructureReference.adoc
@@ -994,11 +994,11 @@ The infrastructure parameters are described hereafter:
 [cols=2*]
 |===
 
-|PBS |`qsub -N %NS_JOBNAME% -o %LOG_FILE% -j oe`
+|PBS |`qsub -N %NS_JOBNAME% -o %LOG_FILE% -j oe %NS_BATCH%`
 
-|SLURM |`sbatch -J %NS_JOBNAME% -o %LOG_FILE%`
+|SLURM |`sbatch -J %NS_JOBNAME% -o %LOG_FILE% %NS_BATCH%`
 
-|LSF |`bsub -J %NS_JOBNAME% -o %LOG_FILE% -e %LOG_FILE%`
+|LSF |`bsub -J %NS_JOBNAME% -o %LOG_FILE% -e %LOG_FILE% %NS_BATCH%`
 
 |===
 +
@@ -1012,6 +1012,9 @@ The command can use patterns which will be replaced dynamically by the ProActive
 |`%LOG_FILE%` |contains a log file path dynamically created by the resource manager and located in side the NSSchedulerHome installation. This log file is useful to debug errors during <<_glossary_ns_cluster_job,cluster job>> submission.
 
 |`%PA_USERNAME%` |contains the current ProActive Scheduler user.
+
+|`%NS_BATCH%` |contains the arguments defined inside workflow tasks using the NS_BATCH generic information.
+
 |===
 
  * *nsKillCommand:* this is the command used to kill ProActive Nodes started previously by the nsSubmitCommand. Similarly to nsSubmitCommand, *nsKillCommand* will vary for each native scheduler syntax: +

--- a/src/docs/user/ProActiveUserGuide.adoc
+++ b/src/docs/user/ProActiveUserGuide.adoc
@@ -129,6 +129,7 @@ link:https://docs.microsoft.com/fr-fr/powershell/scripting/overview?view=powersh
 link:https://en.wikipedia.org/wiki/VBScript[VBScript, window="_blank"],
 link:https://www.r-project.org/[R, window="_blank"],
 link:https://www.perl.org/[Perl, window="_blank"],
+link:https://www.php.net/[PHP, window="_blank"],
 link:https://www.gnu.org/software/bash/[Bash, window="_blank"],
 link:https://en.wikipedia.org/wiki/Unix_shell[Any Unix Shell, window="_blank"],
 link:https://en.wikipedia.org/wiki/Cmd.exe[Windows CMD, window="_blank"],
@@ -878,6 +879,8 @@ resultMetadata.put("content.type","image/png")
 ----
 
 A Task result can be added to the list of results of a Job, see section <<_result_list>> below.
+
+NOTE: The specific result metadata described above can also be set using <<_generic_information,Generic Information>>. For example, defining the generic information _content.type = text/html_ is equivalent to adding this value to the *resultMetadata* map.
 
 === Job Results
 
@@ -2584,17 +2587,6 @@ include::./references/DataConnectors.adoc[]
 == Addons
 
 include::./references/StatisticsOnProActiveJobsAndResourceUsageReference.adoc[]
-
-=== PHP Task
-
-The PHP task is a special, predefined task which executes a PHP script on a ProActive Node’s local PHP installation.
-The PHP script to execute will be downloaded from the ProActive server <<_global_and_user_spaces, global space>>. So, the PHP script must be present in the dataspace beforehand. The task can also be modified to download the PHP script from other sources. Log forwarding and log streaming during PHP execution is conveniently available through the Scheduler portal.
-
-==== Node configuration
-For a ProActive Node to execute a PHP script, PHP must be installed on the machine of the ProActive Node. The PHP task has a <<_selection,selection script>> which validates a correct PHP installation by searching the PATH and validating if the PHP can be executed successfully.
-The static selection script validates the PHP execution once and stores the result in the cache, so removing or installing PHP requires a restart of the node or a switch to the dynamic selection script.
-The selection script predefined in the PHP task does not validate the PHP version, therefore it is advised to use the same PHP version on the ProActive Nodes or to improve the selection script itself.
-
 
 == Reference
 

--- a/src/docs/user/references/ScriptEngines.adoc
+++ b/src/docs/user/references/ScriptEngines.adoc
@@ -85,6 +85,11 @@ NOTE: Script engine naming is case-sensitive
 |Linux, Mac, Windows
 |Perl must be installed
 
+|`php`
+|An engine able to create html content using PHP interpreter
+|Linux, Mac, Windows
+|PHP must be installed
+
 |`scalaw`
 |An engine able to run Scala scripts
 |Linux, Mac, Windows

--- a/src/docs/user/references/ScriptLanguageSupport.adoc
+++ b/src/docs/user/references/ScriptLanguageSupport.adoc
@@ -5,7 +5,7 @@ The main difference between the two script engines is that the Shell script engi
 Both engines features the following behaviors:
 
  * Script bindings are translated as environment variables.
- * Workflow variables are un-modifiable except by using a post-script written in another language such as the `update_variables_from_file` script.
+ * Workflow variables cannot be modified by shell scripts except when adding a link:../user/ProActiveUserGuide.html#_pre_post_clean[post] script written in another language such as the `update_variables_from_file` script.
  * The _result_ of the script engine execution corresponds to the return code of the bash or shell process executed.
 
 Example `bash` script (the shebang notation is omitted):
@@ -113,7 +113,7 @@ Windows Cmd script engine behaves similarly as <<_bash_and_shell,bash script eng
 It features the following behaviors:
 
  * Script bindings are translated as environment variables.
- * Workflow variables are un-modifiable except by using a post-script written in another language such as the `update_variables_from_file` script (see <<_bash_and_shell,Bash script language>> for further explanations).
+ * Workflow variables cannot be modified by Windows Cmd scripts except when adding a link:../user/ProActiveUserGuide.html#_pre_post_clean[post] script written in another language such as the `update_variables_from_file` script (see <<_bash_and_shell,Bash script language>> for further explanations).
  * The _result_ of the script engine execution corresponds to the return code of the `cmd.exe` process executed.
 
 Example variable usage:
@@ -131,7 +131,7 @@ VBScript engine behaves similarly as <<_windows_cmd,Windows CMD>> but using visu
 It features the following behaviors:
 
 * Script bindings are translated as environment variables. They must be accessed inside the script as a process variable.
-* Workflow variables are un-modifiable except by using a post-script written in another language such as the `update_variables_from_file` script (see <<_bash_and_shell,Bash script language>> for further explanations).
+* Workflow variables cannot be modified by VB scripts except adding a link:../user/ProActiveUserGuide.html#_pre_post_clean[post] script written in another language such as the `update_variables_from_file` script (see <<_bash_and_shell,Bash script language>> for further explanations).
 * The _result_ of the script engine execution corresponds to the return code of the `cscript.exe` process executed.
 
 Example variable usage:
@@ -361,10 +361,10 @@ When an internal PowerShell type needs to be used by another language than Power
 
 === Perl
 
-The Perl script engines features the following behaviors:
+The Perl script engine features the following behaviors:
 
  * Script bindings are translated as environment variables.
- * Workflow variables are un-modifiable except by using a post-script written in another language such as the `update_variables_from_file` script (see <<_bash_and_shell,Bash script language>> for further explanations).
+ * Workflow variables cannot be modified by Perl scripts except when adding a link:../user/ProActiveUserGuide.html#_pre_post_clean[post] script written in another language such as the `update_variables_from_file` script (see <<_bash_and_shell,Bash script language>> for further explanations).
  * The _result_ of the script engine execution corresponds to the return code of the `perl` process executed.
 
 In that sense, the Perl script engine behaves similarly as the Bash or Cmd script engines.
@@ -373,7 +373,7 @@ Please refer to link:../user/ProActiveUserGuide.html#_variables_quick_reference[
 
 Inside Perl, you can access environment variables using the *%ENV* hash.
 
-The aim of next examples is to clarify how script engine bindings can be accessed inside Perl scripts.
+Next examples clarify how script engine bindings can be accessed inside Perl scripts.
 
 A workflow variable can be accessed using system environment variables:
 
@@ -394,6 +394,51 @@ Or another script binding (for example, USERSPACE):
 [source, perl]
 ----
 my $USERSPACE= $ENV{"USERSPACE"};
+----
+
+=== PHP
+
+The PHP script engine features the following behaviors:
+
+* Script bindings are translated as environment variables.
+* Workflow variables cannot be modified by PHP scripts except when adding a link:../user/ProActiveUserGuide.html#_pre_post_clean[post] script written in another language such as the `update_variables_from_file` script (see <<_bash_and_shell,Bash script language>> for further explanations).
+* PHP script engine is meant to return HTML content and makes use of link:../user/ProActiveUserGuide.html#_assigning_metadata_to_task_result[result metadata] through the *content.type*="text/html" link:../user/ProActiveUserGuide.html#_generic_information[generic information]. Using the script engine without defining this generic information in the task is not recommended.
+* The _result_ of the script engine execution is a byte array containing the HTML content produced by the `php` command. In case the `php` command returns a non zero value, the result of the script engine execution will be the command exit code and the associated workflow task will be in error.
+
+NOTE: The `php` command returns a non-zero exit code only in case of syntax errors. When runtime issues occur, PHP will generally output warnings and the `php` command will return a zero exit code, not triggering a workflow task failure. This can be modified by using PHP exception mechanism and calling `exit(error_code)` in case of serious failures.
+
+* The PHP script engine is not well adapted to link:../user/ProActiveUserGuide.html#_pre_post_clean[pre], link:../user/ProActiveUserGuide.html#_pre_post_clean[post] or link:../user/ProActiveUserGuide.html#_pre_post_clean[clean] script execution. Even though pre, post of clean scripts can be defined using the PHP script engine, they will not produce any HTML output in these contexts.
+
+Inside PHP, you can access environment variables using the *getenv()* function.
+
+Next examples clarify how script engine bindings can be accessed inside PHP scripts.
+Please refer to link:../user/ProActiveUserGuide.html#_variables_quick_reference[Script Bindings Reference] for the complete list of bindings accessible through environment variables.
+
+A workflow variable can be accessed using system environment variables:
+
+[source, php]
+----
+<?php
+    echo "<p>Hello World from <b>job ".getenv("variables_PA_JOB_ID")."</b></p>";
+?>
+----
+
+Similarly, the result of a parent task:
+
+[source, php]
+----
+<?php
+    echo "<p>Result of parent task is <b>".getenv("results_0")."</b></p>";
+?>
+----
+
+Or another script binding (for example, USERSPACE):
+
+[source, php]
+----
+<?php
+    echo "<p>Userspace is located at <b>".getenv("USERSPACE")."</b></p>";
+?>
 ----
 
 === Docker Compose

--- a/src/docs/user/references/Tasks.adoc
+++ b/src/docs/user/references/Tasks.adoc
@@ -75,7 +75,7 @@ Please find in the table below a further description of these tasks.
 |Perl must be installed
 
 |PHP
-|A custom <<../user/ProActiveUserGuide.adoc#_script_tasks,Script Task>> able to call the `php` command to run PHP scripts
+|Sample <<../user/ProActiveUserGuide.adoc#_script_tasks,Script Task>> using the `php` script engine.
 |Linux,Mac,Windows
 |PHP interpreter must be installed
 

--- a/src/docs/user/references/VariablesReference.adoc
+++ b/src/docs/user/references/VariablesReference.adoc
@@ -34,7 +34,7 @@ The order in this list corresponds to the task life-cycle order.
 
 | *Task arguments*. Arguments of a script defined in the workflow. Available via all kind of scripts, when referencing an external file or directly as XML elements.
 | ... = args[0];
-| Passed to native executable.
+| Passed to native executable. Can also be used with $args_0
 | -
 | all scripts, as external file, or XML element
 | -
@@ -51,21 +51,21 @@ The order in this list corresponds to the task life-cycle order.
 | -
 | -
 | <<_control_flow_scripts,flow>> (if)
-| bash, cmd, perl, vbscript
+| bash, cmd, perl, php, vbscript
 
 | *Parallel runs*. Number of replications. See <<_replicate, replication>>.
 | runs = 3;
 | -
 | -
 | <<_control_flow_scripts,flow>> (replicate)
-| bash, cmd, perl, vbscript
+| bash, cmd, perl, php, vbscript
 
 | *Loop variable*. A boolean variable used in a flow script to decide if the loop continues or not. See <<_control_flow_scripts, loop>>.
 | loop = false;
 | -
 | -
 | <<_control_flow_scripts,flow>> (replicate) (loop)
-| bash, cmd, perl, vbscript
+| bash, cmd, perl, php, vbscript
 
 | *Task progress*. Represents the progress of the task. Can be set to a value between 0 and 100.
 | import org.ow2.proactive.scripting.helper.progress.ProgressFile;
@@ -196,16 +196,16 @@ ProgressFile.setProgress(variables.get("PA_TASK_PROGRESS_FILE"), 50);
 
 | *Third party credentials*. Credentials stored on the server for this user account. See <<_managing_third_party_credentials>>
 | credentials.get( "pw" )
-| -
+| $credentials_pw
 | $credentials_pw (only in the task arguments)
 | <<_fork_environment, environment>>, <<_pre_post_clean, pre>>, <<_script_tasks, task>>, <<_pre_post_clean, post>>, <<_pre_post_clean, clean>>, <<_control_flow_scripts,flow>>
 | -
 
 | *SSH private key*. Private SSH Key used at login. See <<_run_computation_with_your_system_account>>.
 | credentials.get( "SSH_PRIVATE_KEY" )
+| $credentials_SSH_PRIVATE_KEY
 | -
-| -
-| <<_fork_environment, environment>>, <<_pre_post_clean, pre>>, <<_script_tasks, task>>, <<_pre_post_clean, post>>, <<_control_flow_scripts,flow>>
+| <<_fork_environment, environment>>, <<_pre_post_clean, pre>>, <<_script_tasks, task>>, <<_pre_post_clean, post>>, <<_pre_post_clean, clean>>, <<_control_flow_scripts,flow>>
 | -
 
 | *Number of nodes*. Number of nodes used by this task. See <<_mpi_application>>.
@@ -269,49 +269,49 @@ ProgressFile.setProgress(variables.get("PA_TASK_PROGRESS_FILE"), 50);
 | -
 | -
 | <<_selection, selection>>
-| bash, cmd, perl, vbscript
+| bash, cmd, perl, php, vbscript
 
 | *Fork Environment*. Fork Environment variable is a link:../javadoc/org/ow2/proactive/scheduler/common/task/ForkEnvironment.html[ForkEnvironment java object] allowing a script to set various initialization parameters of the forked JVM. See <<_fork_environment, Fork Environment>>
 | forkEnvironment.setJavaHome( "/usr/java/default" )
 | -
 | -
 | <<_fork_environment, environment>>
-| bash, cmd, perl, R, powershell, vbscript
+| bash, cmd, perl, php, R, powershell, vbscript
 
 | *Scheduler API*. Scheduler API variable is a link:../javadoc/org/ow2/proactive/scheduler/task/client/SchedulerNodeClient.html[SchedulerNodeClient java object] which can connect to the ProActive Scheduler frontend and interact directly with its <<_task_apis,API>>.
 | schedulerapi.connect()
 | -
 | -
 | <<_fork_environment, environment>>, <<_pre_post_clean, pre>>, <<_script_tasks, task>>, <<_pre_post_clean, post>>, <<_pre_post_clean, clean>>, <<_control_flow_scripts,flow>>
-| bash, cmd, perl, R, powershell, vbscript
+| bash, cmd, perl, php, R, powershell, vbscript
 
 | *Resource Manager API*. Resource Manager API variable which can connect to the ProActive RM frontend and interact directly with its <<_task_apis,API>>.
 | rmapi.connect()
 | -
 | -
 | <<_fork_environment, environment>>, <<_pre_post_clean, pre>>, <<_script_tasks, task>>, <<_pre_post_clean, post>>, <<_pre_post_clean, clean>>, <<_control_flow_scripts,flow>>
-| bash, cmd, perl, R, powershell, vbscript
+| bash, cmd, perl, php, R, powershell, vbscript
 
 | *UserSpace API*. UserSpace API variable is a link:../javadoc/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.html[DataSpaceNodeClient java object] which can connect to the <<_global_and_user_spaces,User Space>> and interact directly with its <<_dataspace_apis,API>>.
 | userspaceapi.connect()
 | -
 | -
 | <<_fork_environment, environment>>, <<_pre_post_clean, pre>>, <<_script_tasks, task>>, <<_pre_post_clean, post>>, <<_pre_post_clean, clean>>, <<_control_flow_scripts,flow>>
-| bash, cmd, perl, R, powershell, vbscript
+| bash, cmd, perl, php, R, powershell, vbscript
 
 | *GlobalSpace API*. GlobalSpace API variable is a link:../javadoc/org/ow2/proactive/scheduler/task/client/DataSpaceNodeClient.html[DataSpaceNodeClient java object] which can connect to the <<_global_and_user_spaces,Global Space>> and interact directly with its <<_dataspace_apis,API>>.
 | globalspaceapi.connect()
 | -
 | -
 | <<_fork_environment, environment>>, <<_pre_post_clean, pre>>, <<_script_tasks, task>>, <<_pre_post_clean, post>>, <<_pre_post_clean, clean>>, <<_control_flow_scripts,flow>>
-| bash, cmd, perl, R, powershell, vbscript
+| bash, cmd, perl, php, R, powershell, vbscript
 
 | *Synchronization API*. Synchronization API variable is a https://www.activeeon.com/public_content/documentation/javadoc/dev/org/ow2/proactive/scheduler/synchronization/Synchronization.html[Synchronization java object] which can connect to the Synchronization Service and interact directly with its <<_task_synchronization_api,API>>.
 | synchronizationapi.createChannel("channel1", false)
 | -
 | -
 | all scripts
-| bash, cmd, perl, R, powershell, vbscript
+| bash, cmd, perl, php, R, powershell, vbscript
 
 |===
 
@@ -367,6 +367,14 @@ For PowerShell:
 [source, PowerShell]
 ----
 Write-Output $variables.Get_Item('key')
+----
+
+For PHP:
+[source, php]
+----
+<?php
+    echo "<p>Value of variable: ".getenv("variables_key")."</b></p>";
+?>
 ----
 
 ==== Script results


### PR DESCRIPTION
 - remove legacy php task documentation
 - add PHP script engine documentation

 Also, not related to PHP:
  - update native scheduler documentation with latest change
  - minor changes in variables reference